### PR TITLE
Start and stop spawning in response to changes in game state

### DIFF
--- a/Assets/Scripts/Managers/SpawnManager.cs
+++ b/Assets/Scripts/Managers/SpawnManager.cs
@@ -1,74 +1,108 @@
 using ObjectPooling;
 using Spawnables;
 using UnityEngine;
-using Utils;
+using Random = UnityEngine.Random;
 
 namespace Managers
 {
-    public sealed class SpawnManager : EverlastingSingleton<SpawnManager>
+    public sealed class SpawnManager : MonoBehaviour
     {
         [SerializeField][Min(5)] private int simultaneousObstacleLimit = 20;
-        [SerializeField][Min(5)] private float spawnInterval = 3f;
+        [SerializeField][Min(5)] private float spawnInterval = 5.0f;
         [Tooltip("The obstacle that is be spawned in the game scene.")]
         [SerializeField] private GameObject obstacleObject;
         
-        [SerializeField] private float _speedMultiplier = 1f;
-        [SerializeField] private float _damageMultiplier = 1f;
+        [SerializeField] private float speedMultiplier = 1.0f;
+        [SerializeField] private float damageMultiplier = 1.0f;
 
         private ObjectPool _obstacles;
 
         private float _topLimit;
         private float _leftLimit;
         private float _rightLimit;
+        private const float ShoreBuffer = 10.0f;
 
-        protected override void Awake()
-        {
-            base.Awake();
-            // Setup object pooling for obstacles
+        private void Awake() {
             _obstacles = ObjectPool.Build(obstacleObject, simultaneousObstacleLimit, simultaneousObstacleLimit);
         }
 
-        private void Start()
-        {
+        private void Start() {
+            // Get the visual limits of the game scene
             _topLimit = GameObject.Find("TopLimit").transform.position.y;
-            _leftLimit = GameObject.Find("Left Shore").transform.position.x;
-            _rightLimit = GameObject.Find("Right Shore").transform.position.x;
+            _leftLimit = GameObject.Find("Left Shore").transform.position.x + ShoreBuffer;
+            _rightLimit = GameObject.Find("Right Shore").transform.position.x - ShoreBuffer;
 
-            StartSpawn(spawnInterval, _damageMultiplier, _speedMultiplier);
+            // Start spawning in response to game state changes
+            GameStateManager.OnFerryingEnter += StartSpawn;
+
+            // Pause spawning in response to game state changes
+            GameStateManager.OnPauseEnter += StopSpawn;
+
+            // Stop spawning in response to game over or restarting the game
+            GameStateManager.OnEndEnter += StopSpawn;
+        }
+
+        private void OnDestroy() {
+            // Deregister all of the delegates
+            GameStateManager.OnFerryingEnter -= StartSpawn;
+            GameStateManager.OnPauseEnter -= StopSpawn;
+            GameStateManager.OnEndEnter -= StopSpawn;
         }
 
         /**
-         * Spawn a random object from the list of spawnable objects.
+         * Start spawning objects at set interval.
          */
-        public void StartSpawn(float interval, float damageMultiplier, float speedMultiplier)
+        private void StartSpawn()
         {
-            _damageMultiplier = damageMultiplier;
-            _speedMultiplier = speedMultiplier;
-
-            InvokeRepeating(nameof(Spawn), 0.0f, interval);
+            InvokeRepeating(nameof(Spawn), 0.0f, spawnInterval);
         }
 
+        /**
+         * Spawn an individual object at a random starting position at the top of the screen.
+         */
         private void Spawn()
         {
-            if (!GameStateManager.Instance.IsGameActive()) return; //TODO: This will mean an random spawn delay after pausing as the timer keeps running.
-
             var obstacle = _obstacles.GetRecyclable();
 
             var length = obstacle.GetComponent<Renderer>().bounds.size.y;
-            var topOffset = _topLimit + (length / 2);
+            var topOffset = _topLimit + length / 2.0f;
 
             obstacle.transform.position = new Vector3(Random.Range(_leftLimit, _rightLimit), topOffset, 0.0f);
 
-            obstacle.GetComponent<Obstacle>().MultiplySpeed(_speedMultiplier);
-            obstacle.GetComponent<Obstacle>().MultiplyDamage(_damageMultiplier);
+            obstacle.GetComponent<Obstacle>().MultiplySpeed(speedMultiplier);
+            obstacle.GetComponent<Obstacle>().MultiplyDamage(damageMultiplier);
         }
 
         /**
-         * Stop spawning objects.
+         * Stop spawning new objects.
          */
-        public void StopSpawn()
+        private void StopSpawn()
         {
             CancelInvoke(nameof(Spawn));
+        }
+
+        /**
+         * Increase the speed of the spawned objects.
+         */
+        public void IncreaseSpeed(float multiplier)
+        {
+            speedMultiplier = multiplier;
+        }
+
+        /**
+         * Increase frequency of the spawned objects.
+         */
+        public void IncreaseFrequency(float multiplier)
+        {
+            spawnInterval = multiplier;
+        }
+
+        /**
+         * Increase the damage of the spawned objects.
+         */
+        public void IncreaseDamage(float multiplier)
+        {
+            damageMultiplier = multiplier;
         }
     }
 }


### PR DESCRIPTION
This PR will enable the `SpawnManager` to start and stop spawning in response to changes in the game state by register to events in the `GameStateManager`. In particular, when the game transitions to `Ferrying`, spawning will start, and when the game transitions to `Pause` or `End` it will stop.