### PR TITLE
Fix souls being changed after pause

### DIFF
--- a/Assets/Scripts/Boat/BoatCapacity.cs
+++ b/Assets/Scripts/Boat/BoatCapacity.cs
@@ -161,7 +161,7 @@ public class BoatCapacity : MonoBehaviour
     /// <returns>The number of units that were not able to fit onto the boat due to load capacity limits.</returns>
     private int IncreaseSouls(int loadToAdd = int.MaxValue)
     {
-        CurrentLoad += loadToAdd;
+        CurrentLoad = loadToAdd;
         return ReduceLoadToFitCapacity();
     }
 

--- a/Assets/Scripts/Managers/DialogueManager.cs
+++ b/Assets/Scripts/Managers/DialogueManager.cs
@@ -138,9 +138,6 @@ public class DialogueManager : MonoBehaviour
         GameStateManager.GameStates previousState = GameStateManager.Instance.PreviousState;
         GameStateManager.GameStates currentState = GameStateManager.Instance.CurrentState;
 
-        //Dont run dialogue if the game was just paused.
-        if (previousState == GameStateManager.GameStates.Pause) return;
-
         //If the game is not ending
         if (currentState != GameStateManager.GameStates.End)
         {

--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections;
 using UnityEngine;
 
-namespace Managers {
-    public class GameStateManager : MonoBehaviour {
+namespace Managers
+{
+    public class GameStateManager : MonoBehaviour
+    {
         public static GameStateManager Instance;
 
         [Serializable]
@@ -35,13 +37,13 @@ namespace Managers {
 
         // When the scene is loaded
         public static event Action OnStartEnter;
-        
+
         // Showing a dialogue overlay
         public static event Action OnDialogueEnter;
 
         //Starting to ferry, fill up on Souls, Run Dialogue
         public static event Action OnFerryingEnter;
-        
+
         public static event Action OnFirstFerry;
 
         //Drop off souls, Repair ship, Run Dialogue
@@ -49,12 +51,13 @@ namespace Managers {
 
         //Game Paused
         public static event Action OnPauseEnter;
+        public static event Action OnPauseExit;
 
         //Game Ended / Ship Destroyed
         public static event Action OnEndEnter;
 
 
-    
+
         private void Awake()
         {
             if (!Instance) Instance = this;
@@ -85,7 +88,7 @@ namespace Managers {
 
         private void GameStart()
         {
-            if(_currentState == GameStates.Start)
+            if (_currentState == GameStates.Start)
                 ChangeState(GameStates.Ferrying);
         }
 
@@ -101,6 +104,13 @@ namespace Managers {
             _previousState = _currentState;
             _currentState = newState;
 
+
+            if (_previousState != GameStates.Pause)
+            {
+                OnPauseExit?.Invoke();
+                return;
+            }
+
             //Invoke GameState event.
             switch (_currentState)
             {
@@ -114,7 +124,6 @@ namespace Managers {
                     break;
                 //Upon reaching the shore of Underworld/Right/Dropoff
                 case GameStates.Returning:
-                    
                     //Calls OnFirstFerry for the first time a ferry trip is successful.
                     OnReturningEnter?.Invoke();
                     if (_previousState == GameStates.Ferrying && !firstFerryCompleted)
@@ -138,7 +147,8 @@ namespace Managers {
         }
 
 
-        public void Resume() {
+        public void Resume()
+        {
             if (_currentState != GameStates.Pause)
             {
                 Debug.LogError($"Cannot resume playing from the {_currentState} state");
@@ -148,7 +158,8 @@ namespace Managers {
             ChangeState(_previousState);
         }
 
-        public bool IsGameActive() {
+        public bool IsGameActive()
+        {
             //Active game modes are Ferrying and Returning
             //Inactive Game Modes are Start, Pause, and End.
             bool isActive = _currentState == GameStates.Ferrying || _currentState == GameStates.Returning;

--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -105,7 +105,7 @@ namespace Managers
             _currentState = newState;
 
 
-            if (_previousState != GameStates.Pause)
+            if (_previousState == GameStates.Pause)
             {
                 OnPauseExit?.Invoke();
                 return;

--- a/Assets/Scripts/Managers/SpawnManager.cs
+++ b/Assets/Scripts/Managers/SpawnManager.cs
@@ -40,6 +40,7 @@ namespace Managers
 
             // Pause spawning in response to game state changes
             GameStateManager.OnPauseEnter += StopSpawn;
+            GameStateManager.OnPauseExit += StartSpawn;
 
             // Stop spawning in response to game over or restarting the game
             GameStateManager.OnEndEnter += StopSpawn;
@@ -50,6 +51,7 @@ namespace Managers
             GameStateManager.OnFerryingEnter -= StartSpawn;
             GameStateManager.OnDialogueEnter -= StopSpawn;
             GameStateManager.OnPauseEnter -= StopSpawn;
+            GameStateManager.OnPauseExit -= StartSpawn;
             GameStateManager.OnEndEnter -= StopSpawn;
         }
 

--- a/Assets/Scripts/UI/HudController.cs
+++ b/Assets/Scripts/UI/HudController.cs
@@ -16,6 +16,7 @@ public class HudController : MonoBehaviour
         GameStateManager.OnPauseExit += ShowHud;
         GameStateManager.OnFerryingEnter += ShowHud;
         GameStateManager.OnReturningEnter += ShowHud;
+        GameStateManager.OnEndEnter += HideHud;
         BoatCapacity.OnSoulsChanged += UpdateSoulDisplays;
     }
 
@@ -26,6 +27,7 @@ public class HudController : MonoBehaviour
         GameStateManager.OnPauseExit -= ShowHud;
         GameStateManager.OnFerryingEnter -= ShowHud;
         GameStateManager.OnReturningEnter -= ShowHud;
+        GameStateManager.OnEndEnter -= HideHud;
         BoatCapacity.OnSoulsChanged -= UpdateSoulDisplays;
     }
 

--- a/Assets/Scripts/UI/HudController.cs
+++ b/Assets/Scripts/UI/HudController.cs
@@ -11,7 +11,9 @@ public class HudController : MonoBehaviour
 
     private void OnEnable()
     {
+        GameStateManager.OnDialogueEnter += HideHud;
         GameStateManager.OnPauseEnter += HideHud;
+        GameStateManager.OnPauseExit += ShowHud;
         GameStateManager.OnFerryingEnter += ShowHud;
         GameStateManager.OnReturningEnter += ShowHud;
         BoatCapacity.OnSoulsChanged += UpdateSoulDisplays;
@@ -19,7 +21,9 @@ public class HudController : MonoBehaviour
 
     private void OnDisable()
     {
+        GameStateManager.OnDialogueEnter -= HideHud;
         GameStateManager.OnPauseEnter -= HideHud;
+        GameStateManager.OnPauseExit -= ShowHud;
         GameStateManager.OnFerryingEnter -= ShowHud;
         GameStateManager.OnReturningEnter -= ShowHud;
         BoatCapacity.OnSoulsChanged -= UpdateSoulDisplays;

--- a/Assets/Scripts/UI/PauseScreenController.cs
+++ b/Assets/Scripts/UI/PauseScreenController.cs
@@ -9,15 +9,13 @@ public class PauseScreenController : MonoBehaviour
     private void OnEnable()
     {
         GameStateManager.OnPauseEnter += ShowUi;
-        GameStateManager.OnFerryingEnter += HideUi;
-        GameStateManager.OnReturningEnter += HideUi;
+        GameStateManager.OnPauseExit += HideUi;
     }
 
     private void OnDisable()
     {
         GameStateManager.OnPauseEnter -= ShowUi;
-        GameStateManager.OnFerryingEnter -= HideUi;
-        GameStateManager.OnReturningEnter -= HideUi;
+        GameStateManager.OnPauseExit -= HideUi;
     }
 
     private void ShowUi()


### PR DESCRIPTION
Lots of issues occur because pause re-enters the other states. Now publishing a separate onPauseExit instead of calling those game state events